### PR TITLE
Refactor ReadFile: leverage ioutil & reduce allocs

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -10,8 +10,7 @@ package golisp
 import (
 	"errors"
 	"fmt"
-	"io"
-	"os"
+	"io/ioutil"
 	"unsafe"
 )
 
@@ -267,23 +266,12 @@ func ParseAll(src string) (result []*Data, err error) {
 }
 
 func ReadFile(filename string) (s string, err error) {
-	fin, err := os.Open(filename)
+	contents, err := ioutil.ReadFile(filename)
 	if err != nil {
 		return
 	}
-	defer fin.Close()
 
-	var contents []byte = make([]byte, 0)
-	for true {
-		buffer := make([]byte, 8192)
-		n, err := fin.Read(buffer)
-		if n == 0 && err == io.EOF {
-			break
-		}
-		contents = append(contents, buffer[:n]...)
-	}
-
-	s = string(contents)
+	s = *(*string)(unsafe.Pointer(&contents))
 	return
 }
 

--- a/parsing_test.go
+++ b/parsing_test.go
@@ -303,3 +303,11 @@ func (s *ParsingSuite) TestParseAndEval(c *C) {
 	c.Assert(TypeOf(result), Equals, IntegerType)
 	c.Assert(IntegerValue(result), Equals, int64(25))
 }
+
+func (s *ParsingSuite) BenchmarkParse(c *C) {
+	c.ResetTimer()
+	for i := 0; i < c.N; i++ {
+		src, _ := ReadFile("tests/list_access_test.lsp")
+		_, _ = ParseAndEval(src)
+	}
+}


### PR DESCRIPTION
Leverage `ioutil.ReadFile()` method to prevent having to open/close the
file ourselves. Also, we end up reducing our memory footprint in 2 ways:
1. Eliminate our internal buffer
2. Eliminate the memory allocation that comes from string([]byte)
   conversion.

From the benchmark included in this test, the running time went down from
17755 ns/op to 14173 ns/op.
