### PR TITLE
Ensure readline support builds on linux and darwin

### DIFF
--- a/goreadline.go
+++ b/goreadline.go
@@ -1,3 +1,4 @@
+// +build linux darwin
 // sniped from https://github.com/rocaltair/goreadline
 package golisp
 


### PR DESCRIPTION
Essentially rename the file to simply goreadline.go and add a build tag at the top of the file so the compiler knows to build it only on darwin and linux, otherwise it'll grab the goreadline_windows.go file.
