### PR TITLE
Changes to nil behavior

### DIFF
--- a/data.go
+++ b/data.go
@@ -1069,6 +1069,11 @@ func evalHelper(d *Data, env *SymbolTableFrame, needFunction bool) (result *Data
 			{
 				d = postProcessFrameShortcuts(d)
 
+				// catch empty cons cell
+				if NilP(d) {
+					return EmptyCons(), nil
+				}
+
 				var function *Data
 				function, err = evalHelper(Car(d), env, true)
 

--- a/data.go
+++ b/data.go
@@ -483,7 +483,7 @@ func StringValue(d *Data) string {
 }
 
 func BooleanValue(d *Data) bool {
-	if d == nil {
+	if NilP(d) {
 		return false
 	}
 
@@ -603,7 +603,7 @@ func PortValue(d *Data) *os.File {
 }
 
 func Length(d *Data) int {
-	if d == nil {
+	if NilP(d) {
 		return 0
 	}
 
@@ -1075,7 +1075,7 @@ func evalHelper(d *Data, env *SymbolTableFrame, needFunction bool) (result *Data
 				if err != nil {
 					return
 				}
-				if function == nil {
+				if NilP(function) {
 					err = errors.New(fmt.Sprintf("Nil when function or macro expected for %s.", String(Car(d))))
 					return
 				}

--- a/data.go
+++ b/data.go
@@ -891,7 +891,7 @@ func String(d *Data) string {
 	switch d.Type {
 	case ConsCellType:
 		{
-			if NilP(Car(d)) && NilP(Cdr(d)) {
+			if NilP(d) {
 				return "()"
 			}
 			var c *Data = d
@@ -917,7 +917,7 @@ func String(d *Data) string {
 		}
 	case AlistType:
 		{
-			if NilP(Car(d)) && NilP(Cdr(d)) {
+			if NilP(d) {
 				return "()"
 			}
 			contents := make([]string, 0, Length(d))
@@ -1068,11 +1068,6 @@ func evalHelper(d *Data, env *SymbolTableFrame, needFunction bool) (result *Data
 		case ConsCellType:
 			{
 				d = postProcessFrameShortcuts(d)
-
-				// catch empty cons cell
-				if Car(d) == nil && Cdr(d) == nil {
-					return nil, nil
-				}
 
 				var function *Data
 				function, err = evalHelper(Car(d), env, true)

--- a/parser.go
+++ b/parser.go
@@ -69,11 +69,6 @@ func makeSymbol(str string) (s *Data, err error) {
 
 func parseConsCell(s *Tokenizer) (sexpr *Data, eof bool, err error) {
 	tok, _ := s.NextToken()
-	if tok == RPAREN {
-		s.ConsumeToken()
-		sexpr = nil
-		return
-	}
 
 	var car *Data
 	var cdr *Data
@@ -365,7 +360,6 @@ func ParseAndEvalAllInEnvironment(src string, env *SymbolTableFrame) (result *Da
 			return
 		}
 	}
-	return
 }
 
 func ParseAndEvalInEnvironment(src string, env *SymbolTableFrame) (result *Data, err error) {

--- a/prim_macros.go
+++ b/prim_macros.go
@@ -61,10 +61,15 @@ func processQuasiquoted(sexpr *Data, level int, env *SymbolTableFrame) (result *
 				return nil, err
 			}
 			r, err := Eval(Car(processed), env)
+			fmt.Printf("%s\n", String(r))
 			if err != nil {
 				return nil, err
 			}
-			return r, nil
+			if NilP(r) {
+				return nil, nil
+			} else {
+				return r, nil
+			}
 		} else {
 			processed, err := processQuasiquoted(Cadr(sexpr), level-1, env)
 			if err != nil {
@@ -79,7 +84,9 @@ func processQuasiquoted(sexpr *Data, level int, env *SymbolTableFrame) (result *
 			if err != nil {
 				return nil, err
 			}
-			parts = append(parts, processed)
+			if processed != nil {
+				parts = append(parts, processed)
+			}
 		}
 		flat, err := Flatten(ArrayToList(parts))
 		if err != nil {

--- a/prim_macros.go
+++ b/prim_macros.go
@@ -61,7 +61,6 @@ func processQuasiquoted(sexpr *Data, level int, env *SymbolTableFrame) (result *
 				return nil, err
 			}
 			r, err := Eval(Car(processed), env)
-			fmt.Printf("%s\n", String(r))
 			if err != nil {
 				return nil, err
 			}

--- a/prim_setup.go
+++ b/prim_setup.go
@@ -23,7 +23,7 @@ func InitLisp() {
 func InitEnvironments() {
 	TopLevelEnvironments = make(map[string]*SymbolTableFrame, 5)
 	Global = NewSymbolTableFrameBelow(nil, "SystemGlobal")
-	Global.Intern("nil")
+	Global.BindTo(Intern("nil"), EmptyCons())
 	Global.BindTo(Intern("system-global-environment"), EnvironmentWithValue(Global))
 }
 

--- a/symbol_table_frame.go
+++ b/symbol_table_frame.go
@@ -239,7 +239,7 @@ func (self *SymbolTableFrame) ValueOfWithFunctionSlotCheck(symbol *Data, needFun
 	if found {
 		return binding.Val
 	} else {
-		return nil
+		return EmptyCons()
 	}
 }
 

--- a/testing.lsp
+++ b/testing.lsp
@@ -64,7 +64,7 @@
                         (lambda (err) (log-error err))))))
 
 (defmacro (assert-true sexpr)
-  `(let ((actual (eval ,sexpr))
+  `(let ((actual ,sexpr)
          (msg (format #f "(assert-true ~A)" ',sexpr)))
      (if actual
          (log-pass msg)
@@ -72,7 +72,7 @@
 
 
 (defmacro (assert-false sexpr)
-  `(let ((actual (eval ,sexpr))
+  `(let ((actual ,sexpr)
          (msg (format #f "(assert-false ~A)" ',sexpr)))
      (if (not actual)
          (log-pass msg)
@@ -80,7 +80,7 @@
 
 
 (defmacro (assert-nil sexpr)
-  `(let ((actual (eval ,sexpr))
+  `(let ((actual ,sexpr)
          (msg (format #f "(assert-null ~A)" ',sexpr)))
      (if (nil? actual)
          (log-pass msg)
@@ -88,7 +88,7 @@
 
 
 (defmacro (assert-not-nil sexpr)
-  `(let ((actual (eval ,sexpr))
+  `(let ((actual ,sexpr)
          (msg (format #f "(assert-not-null ~A)" ',sexpr)))
      (if (not (nil? actual))
          (log-pass msg)
@@ -148,4 +148,3 @@
   (set! verbose-tests (not (nil? optionals)))
   (let ((t (time (load test-file))))
     (dump-summary t)))
-

--- a/tests/environment_test.lsp
+++ b/tests/environment_test.lsp
@@ -3,7 +3,7 @@
 (context "environment support"
 
          ()
-         
+
          (it "lets you get the global environment"
              (assert-not-nil (system-global-environment)))
 
@@ -30,8 +30,8 @@
              (assert-error (environment-bound-names 5))
              (assert-error (environment-macro-names 5))
              (assert-error (environment-bindings 5))
-             (assert-error (environment-reference-type? 5 'a))
-             (assert-error (environment-reference-type? (system-global-environment) 5))
+             (assert-error (environment-reference-type 5 'a))
+             (assert-error (environment-reference-type (system-global-environment) 5))
              (assert-error (environment-bound? 5 'a))
              (assert-error (environment-bound? (system-global-environment) 5))
              (assert-error (environment-assigned? 5 'a))
@@ -40,7 +40,7 @@
 
              (defmacro (test-macro) )
              (assert-error (environment-assigned? (system-global-environment) 'test-macro))
-             
+
              (assert-error (environment-lookup 5 'a))
              (assert-error (environment-lookup (system-global-environment) 5))
              (assert-error (environment-lookup (system-global-environment) '____foobar))

--- a/tests/math_test.lsp
+++ b/tests/math_test.lsp
@@ -7,7 +7,7 @@
 (context "math"
 
          ()
-         
+
          (it arithmetic-test
              (assert-eq (+ 5 5)
                         10)
@@ -33,7 +33,7 @@
              (assert-false (< y z))
              (assert-error (< "a" 5))
              (assert-error (< 5 "a"))
-             
+
              (assert-false (> xx y))
              (assert-true (> z xx))
              (assert-error (> "a" 5))
@@ -116,16 +116,15 @@
          (it general-math-errors
              (assert-error (/ 3 0))
              (assert-error (% 3.5 6))
-             (assert-error (& 6 4.7))
              (assert-error (min '(1 d)))
              (assert-error (max 5.4 i))
              (assert-error (floor 'd))
-             (assert-error (celing 'd))
+             (assert-error (ceiling 'd))
              (assert-error (abs "hi"))
              (assert-error (zero? 'zero))
              (assert-error (positive? +))
-             (assert-error (negative '-))
+             (assert-error (negative? '-))
              (assert-error (even? "j"))
-             (assert-error (odd 'r))
+             (assert-error (odd? 'r))
              (assert-error (sign 's)))
 )

--- a/tests/nil_test.lsp
+++ b/tests/nil_test.lsp
@@ -1,0 +1,11 @@
+;;; -*- mode: Scheme -*-
+
+(context "nil"
+
+         ()
+
+         (it "can parse and compare nil"
+                   (assert-nil '())
+                   (assert-not-nil '(()))
+                   (assert-not-nil '(()()))
+                   (assert-error ())))

--- a/tests/nil_test.lsp
+++ b/tests/nil_test.lsp
@@ -8,4 +8,4 @@
                    (assert-nil '())
                    (assert-not-nil '(()))
                    (assert-not-nil '(()()))
-                   (assert-error ())))
+                   (assert-nil ())))

--- a/util.go
+++ b/util.go
@@ -8,9 +8,12 @@
 package golisp
 
 func ArrayToList(sexprs []*Data) *Data {
-	head := EmptyCons()
+	head := Cons(nil, EmptyCons())
 	lastCell := head
 	for _, element := range sexprs {
+		if element == nil {
+			element = EmptyCons()
+		}
 		newCell := Cons(element, nil)
 		ConsValue(lastCell).Cdr = newCell
 		lastCell = newCell
@@ -19,9 +22,12 @@ func ArrayToList(sexprs []*Data) *Data {
 }
 
 func ArrayToListWithTail(sexprs []*Data, tail *Data) *Data {
-	head := EmptyCons()
+	head := Cons(nil, EmptyCons())
 	lastCell := head
 	for _, element := range sexprs {
+		if element == nil {
+			element = EmptyCons()
+		}
 		newCell := Cons(element, nil)
 		ConsValue(lastCell).Cdr = newCell
 		lastCell = newCell


### PR DESCRIPTION
This is mainly two changes for nil. The first is parsing nil values as empty cons cells internally instead of null. This makes it possible to distinguish `'()` from `'(())`. Most places this works fine but there were a few cases which explicitly check for null instead of a Nil value, so those had to be fixed. Think I got all of them.

The second is making evaluating a nil value an eval error.

I also fixed a couple tests which were throwing errors for the wrong reasons.