### PR TITLE
Implement "join" primitive for processes

### DIFF
--- a/lisp/testing.lsp
+++ b/lisp/testing.lsp
@@ -124,6 +124,14 @@
                (lambda ()
                  (log-failure msg "expected an error, but there wasn't")))))
 
+(defmacro (assert-nerror **sexpr**)
+  `(let ((msg (format #f "(assert-nerror ~A)" ',**sexpr**)))
+     (on-error ,**sexpr**
+               (lambda (err)
+                 (log-failure msg (format #f "expected no error, but error was ~A" err)))
+               (lambda ()
+                 (log-pass msg)))))
+
 (define (dump-summary duration)
   (format #t "~%Ran ~A tests in ~A seconds~%"
           (+ number-of-passes number-of-failures number-of-errors)

--- a/main/golisp.go
+++ b/main/golisp.go
@@ -33,7 +33,7 @@ func test() {
 	}
 
 	testCommand := fmt.Sprintf("(%s \"%s\"%s)", testFunction, testName, verboseFlag)
-	golisp.ProcessFile("testing.lsp")
+	golisp.ProcessFile("lisp/testing.lsp")
 	golisp.ParseAndEval(testCommand)
 }
 

--- a/prim_concurrency.go
+++ b/prim_concurrency.go
@@ -169,6 +169,11 @@ func AbandonImpl(args *Data, env *SymbolTableFrame) (result *Data, err error) {
 	}
 
 	proc := (*Process)(ObjectValue(procObj))
+
+	if proc.ScheduleTimer == nil {
+		return nil, ProcessError("tried to adandon a Process that isn't scheduled", env)
+	}
+
 	proc.Abort <- true
 	return StringWithValue("OK"), nil
 }
@@ -182,6 +187,11 @@ func ResetTimeoutImpl(args *Data, env *SymbolTableFrame) (result *Data, err erro
 	}
 
 	proc := (*Process)(ObjectValue(procObj))
+
+	if proc.ScheduleTimer == nil {
+		return nil, ProcessError("tried to reset a Process that isn't scheduled", env)
+	}
+
 	var str string
 	select {
 	case proc.Restart <- true:

--- a/tests/concurrency_test.lsp
+++ b/tests/concurrency_test.lsp
@@ -1,0 +1,35 @@
+;;; -*- mode: Scheme -*-
+
+(context "concurrency"
+
+         ()
+
+         (it "should wait for the task to finish on join"
+             (define x 1)
+             (assert-eq (begin
+                          (define f (fork (lambda (proc) (set! x 2) 3)))
+                          (join f)
+                          x)
+                        2))
+
+         (it "should return the task return value on join"
+             (define x 1)
+             (assert-eq (begin
+                          (define f (fork (lambda (proc) (set! x 2) 3)))
+                          (join f))
+                        3))
+
+         (it "should error when trying to join twice"
+             (define x 1)
+             (assert-error (begin
+                          (define f (fork (lambda (proc) ())))
+                          (join f)
+                          (join f))))
+
+         (it "shouldn't allow resetting or abandoning non-scheduled tasks"
+             (define f (fork (lambda (proc) ())))
+             (define s (schedule 1 (lambda (proc) ())))
+             (assert-error (reset-timeout f))
+             (assert-error (abandon f))
+             (assert-nerror (reset-timeout s))
+             (assert-nerror (abandon s))))

--- a/tests/concurrency_test.lsp
+++ b/tests/concurrency_test.lsp
@@ -2,33 +2,27 @@
 
 (context "concurrency"
 
-         ()
+         (
+             (define x 1)
+             (define f (fork (lambda (proc) (set! x 2) 3)))
+             (define s (schedule 0 (lambda (proc) ())))
+         )
 
          (it "should wait for the task to finish on join"
-             (define x 1)
              (assert-eq (begin
-                          (define f (fork (lambda (proc) (set! x 2) 3)))
                           (join f)
                           x)
                         2))
 
          (it "should return the task return value on join"
-             (define x 1)
-             (assert-eq (begin
-                          (define f (fork (lambda (proc) (set! x 2) 3)))
-                          (join f))
-                        3))
+             (assert-eq (join f) 3))
 
          (it "should error when trying to join twice"
-             (define x 1)
              (assert-error (begin
-                          (define f (fork (lambda (proc) ())))
-                          (join f)
-                          (join f))))
+                             (join f)
+                             (join f))))
 
          (it "shouldn't allow resetting or abandoning non-scheduled tasks"
-             (define f (fork (lambda (proc) ())))
-             (define s (schedule 1 (lambda (proc) ())))
              (assert-error (reset-timeout f))
              (assert-error (abandon f))
              (assert-nerror (reset-timeout s))


### PR DESCRIPTION
This allows an easy way to make sure a process is complete and also allows getting return values from forked/scheduled processes.

This also adds some lisp tests for the concurrency functions and adds checks to "reset-timeout" and "abandon" so they error if called on non-scheduled processes.