### PR TITLE
Change Eval to wrap returned errors from Apply with `%w`

### DIFF
--- a/data.go
+++ b/data.go
@@ -1172,7 +1172,7 @@ func evalHelper(d *Data, env *SymbolTableFrame, needFunction bool) (result *Data
 
 				result, err = Apply(function, args, env)
 				if err != nil {
-					err = errors.New(fmt.Sprintf("\nEvaling %s. %s", String(d), err))
+					err = fmt.Errorf("\nEvaling %s. %w", String(d), err)
 					return
 				} else if DebugReturnValue != nil {
 					result = DebugReturnValue

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,10 @@
+module github.com/steelseries/golisp
+
+go 1.13
+
+require (
+	github.com/SteelSeries/bufrr v0.0.0-20161129220322-72103137aa3c
+	github.com/SteelSeries/set.v0 v0.0.0-20141210084824-27c40922c40b
+	github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e // indirect
+	gopkg.in/check.v1 v1.0.0-20200902074654-038fdea0a05b
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,11 @@
+github.com/SteelSeries/bufrr v0.0.0-20161129220322-72103137aa3c h1:SlXEIQaashOxRg92emqhRAAUma1GmJW4t1y49om03Ck=
+github.com/SteelSeries/bufrr v0.0.0-20161129220322-72103137aa3c/go.mod h1:B80GUChy+pCjfTRNgr9KKXfMOGNhVwl2cQqyMjoyQ5s=
+github.com/SteelSeries/set.v0 v0.0.0-20141210084824-27c40922c40b h1:5N4IvGvzYGR7YIP1tP2OVilofpF4vYBxIPHR5jlQUNM=
+github.com/SteelSeries/set.v0 v0.0.0-20141210084824-27c40922c40b/go.mod h1:r9NILMoT1QVpaqPvG2qoS+z89p9A//e6ukKUnDljwn8=
+github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
+github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
+github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
+github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e h1:fD57ERR4JtEqsWbfPhv4DMiApHyliiK5xCTNVSPiaAs=
+github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
+gopkg.in/check.v1 v1.0.0-20200902074654-038fdea0a05b h1:QRR6H1YWRnHb4Y/HeNFCTJLFVxaq6wH4YuVdsUOr75U=
+gopkg.in/check.v1 v1.0.0-20200902074654-038fdea0a05b/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=


### PR DESCRIPTION
Previously the `Eval()` function could return an error that dropped all type information. This PR changes one line to wrap the error with `%w` instead of just printing the string. 

This way, custom error types can be returned from `Eval()` and compared with `errors.Is()` and `errors.As()`. Other returned errors in the golisp codebase can remain unchanged because they don't use a wrapped `fmt.Printf()` or similar.

I added a `go.mod` and `go.sum` file as well. I had trouble building locally without them. 

