### PR TITLE
Check patterns before calling fmt.Sscanf in parseNumArgs

### DIFF
--- a/parsing_test.go
+++ b/parsing_test.go
@@ -8,8 +8,9 @@
 package golisp
 
 import (
-	. "gopkg.in/check.v1"
 	"testing"
+
+	. "gopkg.in/check.v1"
 )
 
 func Test(t *testing.T) { TestingT(t) }
@@ -346,4 +347,44 @@ func (s *ParsingSuite) BenchmarkParse(c *C) {
 		src, _ := ReadFile("tests/list_access_test.lsp")
 		_, _ = ParseAndEval(src)
 	}
+}
+
+func (s *ParsingSuite) Test_isNum(c *C) {
+	c.Assert(isJustNum("0"), Equals, true)
+	c.Assert(isJustNum("5"), Equals, true)
+	c.Assert(isJustNum("9"), Equals, true)
+	c.Assert(isJustNum("10"), Equals, true)
+	c.Assert(isJustNum("124050"), Equals, true)
+
+	c.Assert(isJustNum("_1"), Equals, false)
+	c.Assert(isJustNum(">=1"), Equals, false)
+	c.Assert(isJustNum("(1)"), Equals, false)
+	c.Assert(isJustNum(""), Equals, false)
+}
+
+func (s *ParsingSuite) Test_isGTE(c *C) {
+	c.Assert(isGTE(">=0"), Equals, true)
+	c.Assert(isGTE(">=1"), Equals, true)
+	c.Assert(isGTE(">=9"), Equals, true)
+	c.Assert(isGTE(">=10"), Equals, true)
+
+	c.Assert(isGTE("10"), Equals, false)
+	c.Assert(isGTE(">="), Equals, false)
+	c.Assert(isGTE("<=-"), Equals, false)
+	c.Assert(isGTE(">=+"), Equals, false)
+}
+
+func (s *ParsingSuite) Test_isRange(c *C) {
+	c.Assert(isRange("(1,1)"), Equals, true)
+	c.Assert(isRange("(10,14)"), Equals, true)
+	c.Assert(isRange("(1,00400)"), Equals, true)
+	c.Assert(isRange("(999991,00400)"), Equals, true)
+
+	c.Assert(isRange("()"), Equals, false)
+	c.Assert(isRange("(,)"), Equals, false)
+	c.Assert(isRange("(,00)"), Equals, false)
+	c.Assert(isRange("(00,)"), Equals, false)
+	c.Assert(isRange("(000)"), Equals, false)
+	c.Assert(isRange("1234)"), Equals, false)
+	c.Assert(isRange("(1234"), Equals, false)
 }

--- a/primitive_function.go
+++ b/primitive_function.go
@@ -77,6 +77,14 @@ func (self *PrimitiveFunction) parseNumArgs(argCount string) {
 		}
 
 		var intTerm int
+
+		// Using `isJustNum`, `isGTE`, and `isRange` to check whether the subsequent calls to `fmt.Sscanf()` will fail.
+		// This avoids a Golang runtime bug caused by `fmt.Sscanf()` using panic+recover internally to return an error.
+		// The bug would clutter the stack trace reported by the race detector when run with `-race`.
+		//
+		// See the following Go github issues regarding the underlying runtime bug
+		// 		https://github.com/golang/go/issues/46095
+		// 		https://github.com/golang/go/issues/26813
 		if isJustNum(term) {
 			n, _ := fmt.Sscanf(term, "%d", &intTerm)
 			if n == 1 {


### PR DESCRIPTION
This PR checks the arguments going into `fmt.Sscanf()` before actually calling it. This reduces the noise on stack traces from the race detector.

The underlying reason is a runtime bug with Golang. Until it is fixed, this PR should help reduce the clutter.

### Background

I've noticed extremely large stack traces when data races are detected in programs built/run with `-race` that include golisp. The stack traces show repeated lines from the `golisp` repo, specifically functions called during the `init()` stage. This shouldn't happen, especially for data races that occur in `main()`. For all intents and purposes, nothing happening in `main()` should have stack knowledge from `init()`.

Example stack trace from the following program, run with `go run -race main.go`. The program forces a data race in main by reading and writing `b` from two different goroutines.

```
package main

import (
	"github.com/steelseries/golisp"
)

func main() {
	_ = golisp.Global // just forcing golisp to be included here

	a := 0
	b := 0
	go func() {
		b = 1
	}()

	go func() {
		a = b
	}()
}
```

Which outputs 
```
==================
WARNING: DATA RACE
Read at 0x00c00012ef30 by goroutine 8:
  main.main.func2()
      F:/Documents/Github/temp/go-test/main.go:49 +0x44

Previous write at 0x00c00012ef30 by goroutine 7:
  main.main.func1()
      F:/Documents/Github/temp/go-test/main.go:45 +0x44

Goroutine 8 (running) created at:
  main.main()
      F:/Documents/Github/temp/go-test/main.go:48 +0xf0
  runtime.main()
      C:/Program Files/Go/src/runtime/proc.go:225 +0x255
  github.com/steelseries/golisp.MakePrimitiveFunction()
      C:/Users/m/go/pkg/mod/github.com/steelseries/golisp@v0.0.0-20201204182246-70da1c96e501/primitive_function.go:44 +0x14a
  github.com/steelseries/golisp.RegisterConcurrencyPrimitives()
      C:/Users/m/go/pkg/mod/github.com/steelseries/golisp@v0.0.0-20201204182246-70da1c96e501/prim_concurrency.go:36 +0x11e
  fmt.Sscanf()
      C:/Program Files/Go/src/fmt/scan.go:114 +0x224
  github.com/steelseries/golisp.(*PrimitiveFunction).parseNumArgs()
      C:/Users/m/go/pkg/mod/github.com/steelseries/golisp@v0.0.0-20201204182246-70da1c96e501/primitive_function.go:80 +0x15c
  github.com/steelseries/golisp.MakePrimitiveFunction()
      C:/Users/m/go/pkg/mod/github.com/steelseries/golisp@v0.0.0-20201204182246-70da1c96e501/primitive_function.go:44 +0x14a
  github.com/steelseries/golisp.RegisterConcurrencyPrimitives()
      C:/Users/m/go/pkg/mod/github.com/steelseries/golisp@v0.0.0-20201204182246-70da1c96e501/prim_concurrency.go:33 +0x6f
  github.com/steelseries/golisp.InitBuiltins()
      C:/Users/m/go/pkg/mod/github.com/steelseries/golisp@v0.0.0-20201204182246-70da1c96e501/prim_setup.go:47 +0x98
  github.com/steelseries/golisp.MakeSpecialForm()

... ommitting the rest
```

<details>
<summary>Here's a zoomed out image of the entire race detector stack trace</summary>

![image](https://user-images.githubusercontent.com/2131159/118007511-d1c38600-b311-11eb-8362-76562b093f82.png)

</details>

The reason for this is that the Go runtime does not unwind the thread sanitizer stack when `panic` is called, so that stack information sticks around for the rest of the goroutine's lifetime. And we see that information whenever the race detector (which uses tsan) outputs the stack trace.

See related issues on the Go github repository, numbers 46095 and 26813. Not linking directly to avoid automatic mentions in those comment threads.

The `init()` function in the `golisp` repo calls `fmt.Sscanf()` multiple times as it initializes primitive functions, using Sscanf to match against different argument patterns (eg "*" , "4", ">=4", "(1,4)"). If one pattern match fails, Sscanf is called again on a different pattern. This continues until we find the matching pattern or run out of patterns to check. 

`fmt.Sscanf()` internally uses `panic` and `recover` to generate errors. Since many of `golisp`'s calls to Sscanf are expected to error, we will always produce the messy stack that we see above on data races.

### Solution

This is not a solution to the underlying runtime bug. Just a solution to messy stack traces resulting from importing golisp. 

We precheck the format of the arguments in `parseNumArgs` to see if they would result in a Sscanf error. If they look good then we pass them to Sscanf. This avoids the panic+recover in Sscanf, and thus the garbage stack traces. 

The output for the above program looks something like this after the change:
```
==================
WARNING: DATA RACE
Read at 0x00c00010a008 by goroutine 7:
  main.main.func2()
      F:/Documents/Github/temp/go-test/main.go:49 +0x44

Previous write at 0x00c00010a008 by goroutine 6:
  main.main.func1()
      F:/Documents/Github/temp/go-test/main.go:45 +0x44

Goroutine 7 (running) created at:
  main.main()
      F:/Documents/Github/temp/go-test/main.go:48 +0xdc

Goroutine 6 (finished) created at:
  main.main()
      F:/Documents/Github/temp/go-test/main.go:44 +0xb0
==================
Found 1 data race(s)
exit status 66
```
